### PR TITLE
Added link of Computer Science Roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
   - [CS50 Harvard](https://www.youtube.com/watch?v=y62zj9ozPOM&list=PLhQjrBD2T3828ZVcVzEIhsHVgjANGZveu)
   - [Audio/Video Courses from Colleges and Universities](http://www.infocobuild.com/education/audio-video-courses/)
   - [Everything Computer Science](https://everythingcomputerscience.com/)
+  - [Computer Science Roadmap](https://roadmap.sh/computer-science)
 - Computer Fundamentals
   - [Algorithms & Data Structures](https://github.com/the-akira/Computer-Science-Resources/blob/master/db/algorithms_data_structures.md)
   - [Computer Architecture](https://github.com/the-akira/computer_science_web_resources/blob/master/db/computer_architecture.md)


### PR DESCRIPTION
Hi @the-akira,

I came across your repository [Computer-Science-Resources](https://github.com/the-akira/Computer-Science-Resources) and found it to be a valuable resource for CS enthusiasts.

While browsing through the repository, I noticed that it was missing links to any structured guides such as the famous ["Computer Science Roadmap"](https://roadmap.sh/computer-science). I took the initiative to submit a ["Pull Request"](https://github.com/the-akira/Computer-Science-Resources/pull/69) adding it in "Getting started" section.

Thank you for your time and effort in maintaining this valuable resource :)

Best,
Mouaaz